### PR TITLE
Allows basic HTML

### DIFF
--- a/src/main/java/codeu/controller/ChatServlet.java
+++ b/src/main/java/codeu/controller/ChatServlet.java
@@ -145,7 +145,7 @@ public class ChatServlet extends HttpServlet {
     settings.prettyPrint(false);
 
 
-    // Allows basic HTML
+    // Allows basic HTML including <a> tags   , disallows images and script 
     String cleanedMessageContent = Jsoup.clean(messageContent, "",Whitelist.basic(), settings);
 
     Message message =

--- a/src/main/java/codeu/controller/ChatServlet.java
+++ b/src/main/java/codeu/controller/ChatServlet.java
@@ -30,6 +30,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.jsoup.Jsoup;
 import org.jsoup.safety.Whitelist;
+import org.jsoup.nodes.Document.OutputSettings;
 
 /** Servlet class responsible for the chat page. */
 public class ChatServlet extends HttpServlet {
@@ -140,8 +141,12 @@ public class ChatServlet extends HttpServlet {
 
     String messageContent = request.getParameter("message");
 
-    // this removes any HTML from the message content
-    String cleanedMessageContent = Jsoup.clean(messageContent, Whitelist.none());
+    OutputSettings settings = new OutputSettings();
+    settings.prettyPrint(false);
+
+
+    // Allows basic HTML
+    String cleanedMessageContent = Jsoup.clean(messageContent, "",Whitelist.basic(), settings);
 
     Message message =
         new Message(

--- a/src/test/java/codeu/controller/ChatServletTest.java
+++ b/src/test/java/codeu/controller/ChatServletTest.java
@@ -207,7 +207,7 @@ public class ChatServletTest {
     ArgumentCaptor<Message> messageArgumentCaptor = ArgumentCaptor.forClass(Message.class);
     Mockito.verify(mockMessageStore).addMessage(messageArgumentCaptor.capture());
     Assert.assertEquals(
-        "Contains html and  content.", messageArgumentCaptor.getValue().getContent());
+        "Contains <b>html</b> and  content.", messageArgumentCaptor.getValue().getContent());
 
     Mockito.verify(mockResponse).sendRedirect("/chat/test_conversation");
   }

--- a/src/test/java/codeu/controller/ChatServletTest.java
+++ b/src/test/java/codeu/controller/ChatServletTest.java
@@ -200,14 +200,14 @@ public class ChatServletTest {
         .thenReturn(fakeConversation);
 
     Mockito.when(mockRequest.getParameter("message"))
-        .thenReturn("Contains <b>html</b> and <script>JavaScript</script> content.");
+        .thenReturn("Contains <b>html</b> and <script>JavaScript</script> content. <img src=smiley.gif alt=Smiley face>, <a href=https://www.w3schools.com/>Visit W3Schools.com!</a> ");
 
     chatServlet.doPost(mockRequest, mockResponse);
 
     ArgumentCaptor<Message> messageArgumentCaptor = ArgumentCaptor.forClass(Message.class);
     Mockito.verify(mockMessageStore).addMessage(messageArgumentCaptor.capture());
     Assert.assertEquals(
-        "Contains <b>html</b> and  content.", messageArgumentCaptor.getValue().getContent());
+        "Contains <b>html</b> and  content. , <a href=\"https://www.w3schools.com/\" rel=\"nofollow\">Visit W3Schools.com!</a> ", messageArgumentCaptor.getValue().getContent());
 
     Mockito.verify(mockResponse).sendRedirect("/chat/test_conversation");
   }


### PR DESCRIPTION
Allows users to use basic HTML (this includes  a, b, blockquote, br, cite, code, dd, dl, dt, em, i, li, ol, p, pre, q, small, span, strike, strong, sub, sup, u, ul, and appropriate attributes). 