### PR TITLE
Direct messages MVP

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <version>3.0.2</version>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/src/main/java/codeu/controller/ChatAddUserServlet.java
+++ b/src/main/java/codeu/controller/ChatAddUserServlet.java
@@ -75,7 +75,6 @@ public class ChatAddUserServlet extends HttpServlet {
         } else {
             conversation.addUser(newUser);
             request.getSession().setAttribute("addNewUserMessage", "Added new user to the conversation!");
-
         }
 
         response.sendRedirect("/chat/" + conversationTitle);

--- a/src/main/java/codeu/controller/ConversationServlet.java
+++ b/src/main/java/codeu/controller/ConversationServlet.java
@@ -119,7 +119,13 @@ public class ConversationServlet extends HttpServlet {
 
     if (conversationStore.isTitleTaken(conversationTitle)) {
       // conversation title is already taken, just go into that conversation instead of creating a new one
-      response.sendRedirect("/chat/" + conversationTitle);
+      Conversation conversation = conversationStore.getConversationWithTitle(conversationTitle);
+      if (conversation.isUserInConversation(username)) {
+        response.sendRedirect("/chat/" + conversationTitle);
+      } else {
+        request.setAttribute("error", "That conversation title is already taken for a group conversation!");
+        request.getRequestDispatcher("/WEB-INF/view/conversations.jsp").forward(request, response);
+      }
       return;
     }
 

--- a/src/main/java/codeu/controller/ConversationServlet.java
+++ b/src/main/java/codeu/controller/ConversationServlet.java
@@ -16,6 +16,7 @@ package codeu.controller;
 
 import static codeu.model.data.Conversation.ConversationType;
 
+import codeu.helper.ConversationHelper;
 import codeu.model.data.Conversation;
 import codeu.model.data.User;
 import codeu.model.store.basic.ConversationStore;
@@ -132,8 +133,8 @@ public class ConversationServlet extends HttpServlet {
 
     Conversation conversation;
     if (request.getParameter("newGroupConversation") != null) {
-      List<User> users = new ArrayList<>();
-      users.add(user);
+      List<String> users = new ArrayList<>();
+      users.add(username);
       conversation = new Conversation(UUID.randomUUID(), user.getId(), conversationTitle, Instant.now(),
               users, ConversationType.GROUP);
     } else {

--- a/src/main/java/codeu/controller/ConversationServlet.java
+++ b/src/main/java/codeu/controller/ConversationServlet.java
@@ -73,7 +73,9 @@ public class ConversationServlet extends HttpServlet {
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response)
       throws IOException, ServletException {
-    List<Conversation> conversations = conversationStore.getAllConversations();
+    String user = (String) request.getSession().getAttribute("user");
+
+    List<Conversation> conversations = conversationStore.getConversationsForUser(user);
     request.setAttribute("conversations", conversations);
     request.getRequestDispatcher("/WEB-INF/view/conversations.jsp").forward(request, response);
   }

--- a/src/main/java/codeu/controller/ConversationServlet.java
+++ b/src/main/java/codeu/controller/ConversationServlet.java
@@ -118,15 +118,16 @@ public class ConversationServlet extends HttpServlet {
     }
 
     if (conversationStore.isTitleTaken(conversationTitle)) {
-      // conversation title is already taken, just go into that conversation instead of creating a new one
+      // title is already taken, if user can access then just go into that conversation instead of creating a new one
       Conversation conversation = conversationStore.getConversationWithTitle(conversationTitle);
       if (conversation.isUserInConversation(username)) {
         response.sendRedirect("/chat/" + conversationTitle);
+        return;
       } else {
-        request.setAttribute("error", "That conversation title is already taken for a group conversation!");
+        request.setAttribute("error", "That title is already taken by a group conversation!");
         request.getRequestDispatcher("/WEB-INF/view/conversations.jsp").forward(request, response);
+        return;
       }
-      return;
     }
 
     Conversation conversation;

--- a/src/main/java/codeu/controller/ProfilePageServlet.java
+++ b/src/main/java/codeu/controller/ProfilePageServlet.java
@@ -7,6 +7,7 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import codeu.helper.ConversationHelper;
 import codeu.model.data.Conversation;
 import codeu.model.data.Profile;
 import codeu.model.data.User;
@@ -122,8 +123,8 @@ public class ProfilePageServlet extends HttpServlet {
 				UUID ownerId = userStore.getUser(user).getId();
 				conversationTitle = id.toString();
 
-				Conversation conversation = new Conversation(id, ownerId, conversationTitle, Instant.now(), users,
-						ConversationType.DIRECT);
+				Conversation conversation = new Conversation(id, ownerId, conversationTitle, Instant.now(),
+						ConversationHelper.getUsernamesFromUsers(users), ConversationType.DIRECT);
 				conversationStore.addConversation(conversation);
 			} else {
 				conversationTitle = directMessageConversation.getTitle();

--- a/src/main/java/codeu/helper/AdminHelper.java
+++ b/src/main/java/codeu/helper/AdminHelper.java
@@ -12,12 +12,14 @@ public class AdminHelper {
         if (user == null)
             return false;
 
-        String[] admins = {"cynthia", "justin", "sergio", "vasuman"};
-        for (String admin : admins) {
-            if (admin.equals(user.toLowerCase()))
-                return true;
-        }
-        return false;
+        return true;
+
+//        String[] admins = {"cynthia", "justin", "sergio", "vasuman"};
+//        for (String admin : admins) {
+//            if (admin.equals(user.toLowerCase()))
+//                return true;
+//        }
+//        return false;
     }
 
 }

--- a/src/main/java/codeu/helper/AdminHelper.java
+++ b/src/main/java/codeu/helper/AdminHelper.java
@@ -12,14 +12,12 @@ public class AdminHelper {
         if (user == null)
             return false;
 
-        return true;
-
-//        String[] admins = {"cynthia", "justin", "sergio", "vasuman"};
-//        for (String admin : admins) {
-//            if (admin.equals(user.toLowerCase()))
-//                return true;
-//        }
-//        return false;
+        String[] admins = {"cynthia", "justin", "sergio", "vasuman"};
+        for (String admin : admins) {
+            if (admin.equals(user.toLowerCase()))
+                return true;
+        }
+        return false;
     }
 
 }

--- a/src/main/java/codeu/helper/ConversationHelper.java
+++ b/src/main/java/codeu/helper/ConversationHelper.java
@@ -1,0 +1,23 @@
+package codeu.helper;
+
+import codeu.model.data.User;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Helper class containing methods pertaining Conversation object instantiation */
+public class ConversationHelper {
+
+    /**
+     * @param users List of User objects to convert to usernames
+     * @return List of Strings, the usernames of param users
+     */
+    public static List<String> getUsernamesFromUsers(List<User> users) {
+        List<String> usernames = new ArrayList<>();
+        for (User user : users) {
+            usernames.add(user.getName());
+        }
+        return usernames;
+    }
+
+}

--- a/src/main/java/codeu/model/data/Conversation.java
+++ b/src/main/java/codeu/model/data/Conversation.java
@@ -173,12 +173,13 @@ public class Conversation {
 
   /**
    * @param currentUser The username of the currently logged in user
-   * returns the title of the DM conversation by checking the username besides currentUser
+   * @return String the title of the direct conversation by checking the username besides currentUser
+   * if the conversation is not direct then return the default title
    * */
   @Nullable
   public String getDirectConversationTitle(String currentUser) {
     if (!isDirectConversation()) {
-      return null;
+      return title;
     }
 
     String userOne = users.get(0);
@@ -189,7 +190,7 @@ public class Conversation {
       return userOne;
     }
 
-    return null;
+    return title;
   }
 
 }

--- a/src/main/java/codeu/model/data/Conversation.java
+++ b/src/main/java/codeu/model/data/Conversation.java
@@ -15,8 +15,8 @@
 package codeu.model.data;
 
 import codeu.model.store.basic.ConversationStore;
-import jdk.internal.jline.internal.Nullable;
 
+import javax.annotation.Nullable;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -175,10 +175,9 @@ public class Conversation {
       return false;
     }
 
-    for (String username2 : users) {
-      if (username.equals(username2)) {
-        return true;
-      }
+    if (users.indexOf(username) != -1) {
+      // the user exists in the users list
+      return true;
     }
 
     return false;

--- a/src/main/java/codeu/model/data/Conversation.java
+++ b/src/main/java/codeu/model/data/Conversation.java
@@ -14,6 +14,7 @@
 
 package codeu.model.data;
 
+import codeu.model.store.basic.ConversationStore;
 import jdk.internal.jline.internal.Nullable;
 
 import java.time.Instant;
@@ -72,17 +73,22 @@ public class Conversation {
     this.title = title;
 
     // Check if list of Users or Strings was given
-    if (users.get(0) instanceof User) {
-      List<String> usernames = new ArrayList<>();
-      for (User user : (List<User>) users) {
-        usernames.add(user.getName());
+    if (users.size() != 0) {
+      if (users.get(0) instanceof User) {
+        List<String> usernames = new ArrayList<>();
+        for (User user : (List<User>) users) {
+          usernames.add(user.getName());
+        }
+        this.users = usernames;
+      } else if (users.get(0) instanceof String) {
+        this.users = (List<String>) users;
+      } else {
+        throw new IllegalArgumentException("Users list should be of type User or String!");
       }
-      this.users = usernames;
-    } else if (users.get(0) instanceof String) {
-      this.users = (List<String>) users;
     } else {
-      throw new IllegalArgumentException("Users list should be of type User or String!");
+      this.users = new ArrayList<>();
     }
+
 
     this.conversationType = conversationType;
   }
@@ -126,6 +132,7 @@ public class Conversation {
       return false;
     }
     users.add(user.getName());
+    ConversationStore.getInstance().updateConversation(this);
     return true;
   }
 
@@ -137,6 +144,7 @@ public class Conversation {
       return false;
     }
     users.add(username);
+    ConversationStore.getInstance().updateConversation(this);
     return true;
   }
 
@@ -155,9 +163,15 @@ public class Conversation {
     return conversationType == ConversationType.GROUP;
   }
 
-  /** Returns whether or not the user is the user List for this Conversation */
+  /** Returns whether or not the user can access this conversation */
   public boolean isUserInConversation(String username) {
-    if (username == null || isNormalConversation()) {
+    if (isNormalConversation()) {
+      return true;
+    }
+
+    // this username null check needs to be under normal conversation check
+    // if user is not logged in they are still able to access the conversation
+    if (username == null) {
       return false;
     }
 

--- a/src/main/java/codeu/model/data/Conversation.java
+++ b/src/main/java/codeu/model/data/Conversation.java
@@ -146,12 +146,12 @@ public class Conversation {
   }
 
   /** Returns whether or not this Conversation is a direct message conversation */
-  public boolean isDirectMessage() {
+  public boolean isDirectConversation() {
     return conversationType == ConversationType.DIRECT;
   }
 
-  /** Returns whether or not this Conversation is a direct message conversation */
-  public boolean isGroupMessage() {
+  /** Returns whether or not this Conversation is a group conversation */
+  public boolean isGroupConversation() {
     return conversationType == ConversationType.GROUP;
   }
 
@@ -176,8 +176,8 @@ public class Conversation {
    * returns the title of the DM conversation by checking the username besides currentUser
    * */
   @Nullable
-  public String getDirectMessageTitle(String currentUser) {
-    if (!isDirectMessage()) {
+  public String getDirectConversationTitle(String currentUser) {
+    if (!isDirectConversation()) {
       return null;
     }
 

--- a/src/main/java/codeu/model/store/basic/ConversationStore.java
+++ b/src/main/java/codeu/model/store/basic/ConversationStore.java
@@ -123,9 +123,9 @@ public class ConversationStore {
   public Conversation getDirectMessageWithUsers(String username1, String username2) {
     for (Conversation conversation : conversations) {
       if (conversation.isDirectMessage()) {
-        List<User> users = conversation.getUsers();
-        String user1 = users.get(0).getName();
-        String user2 = users.get(1).getName();
+        List<String> usernames = conversation.getUsers();
+        String user1 = usernames.get(0);
+        String user2 = usernames.get(1);
         if ((user1.equals(username1) && user2.equals(username2)) ||
                 (user1.equals(username2) && user2.equals(username1))) {
           return conversation;

--- a/src/main/java/codeu/model/store/basic/ConversationStore.java
+++ b/src/main/java/codeu/model/store/basic/ConversationStore.java
@@ -102,13 +102,9 @@ public class ConversationStore {
     List<Conversation> userConversations = new ArrayList<>();
 
     for (Conversation conversation : conversations) {
-      if (conversation.isNormalConversation()) {
-        userConversations.add(conversation);
-      } else if (conversation.isUserInConversation(username)) {
-        // not a normal conversation, check if the user is in the user List of the conversation
+      if (conversation.isUserInConversation(username)) {
         userConversations.add(conversation);
       }
-
     }
 
     return userConversations;
@@ -148,6 +144,10 @@ public class ConversationStore {
   public void deleteAllConversations() {
     persistentStorageAgent.deleteAllConversations(conversations);
     conversations.clear();
+  }
+
+  public void updateConversation(Conversation conversation) {
+    persistentStorageAgent.updateConversation(conversation);
   }
 
 }

--- a/src/main/java/codeu/model/store/basic/ConversationStore.java
+++ b/src/main/java/codeu/model/store/basic/ConversationStore.java
@@ -15,7 +15,6 @@
 package codeu.model.store.basic;
 
 import codeu.model.data.Conversation;
-import codeu.model.data.User;
 import codeu.model.store.persistence.PersistentStorageAgent;
 import java.util.ArrayList;
 import java.util.List;
@@ -122,7 +121,7 @@ public class ConversationStore {
    * @return The Conversation if it exists, null otherwise */
   public Conversation getDirectMessageWithUsers(String username1, String username2) {
     for (Conversation conversation : conversations) {
-      if (conversation.isDirectMessage()) {
+      if (conversation.isDirectConversation()) {
         List<String> usernames = conversation.getUsers();
         String user1 = usernames.get(0);
         String user2 = usernames.get(1);

--- a/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
+++ b/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
@@ -225,7 +225,7 @@ public class PersistentDataStore {
       }
 
       // this line prevents ChatAddUserServletTest from NPE during doPostAddUser test
-      if (conversationEntity == null) return;
+//      if (conversationEntity == null) return;
 
       conversationEntity.setProperty("users", conversation.getUsers());
       datastore.put(conversationEntity);

--- a/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
+++ b/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
@@ -213,6 +213,24 @@ public class PersistentDataStore {
     datastore.put(conversationEntity);
   }
 
+  public void updateConversation(Conversation conversation) {
+      Key conversationKey = KeyFactory.createKey("chat-conversations", conversation.getId().toString());
+      Entity conversationEntity;
+
+      try {
+          conversationEntity = datastore.get(conversationKey);
+      } catch (EntityNotFoundException e) {
+          e.printStackTrace();
+          return;
+      }
+
+      // this line prevents ChatAddUserServletTest from NPE during doPostAddUser test
+      if (conversationEntity == null) return;
+
+      conversationEntity.setProperty("users", conversation.getUsers());
+      datastore.put(conversationEntity);
+  }
+
   /** Write a Profile object to the Datastore service. */
 	public void writeThrough(Profile profile) {
 		Query query = new Query("user-profiles");

--- a/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
+++ b/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
@@ -14,6 +14,8 @@
 
 package codeu.model.store.persistence;
 
+import static codeu.model.data.Conversation.ConversationType;
+
 import codeu.model.data.Conversation;
 import codeu.model.data.Message;
 import codeu.model.data.Profile;
@@ -99,7 +101,15 @@ public class PersistentDataStore {
         UUID ownerUuid = UUID.fromString((String) entity.getProperty("owner_uuid"));
         String title = (String) entity.getProperty("title");
         Instant creationTime = Instant.parse((String) entity.getProperty("creation_time"));
-        Conversation conversation = new Conversation(uuid, ownerUuid, title, creationTime);
+        ConversationType type = ConversationType.valueOf((String) entity.getProperty("type"));
+
+        Conversation conversation;
+        if (type == ConversationType.NORMAL) {
+            conversation = new Conversation(uuid, ownerUuid, title, creationTime);
+        } else {
+            List<String> users = (List<String>) entity.getProperty("users");
+            conversation = new Conversation(uuid, ownerUuid, title, creationTime, users, type);
+        }
         conversations.add(conversation);
       } catch (Exception e) {
         // In a production environment, errors should be very rare. Errors which may
@@ -198,6 +208,8 @@ public class PersistentDataStore {
     conversationEntity.setProperty("owner_uuid", conversation.getOwnerId().toString());
     conversationEntity.setProperty("title", conversation.getTitle());
     conversationEntity.setProperty("creation_time", conversation.getCreationTime().toString());
+    conversationEntity.setProperty("users", conversation.getUsers());
+    conversationEntity.setProperty("type", conversation.getConversationType().name());
     datastore.put(conversationEntity);
   }
 

--- a/src/main/java/codeu/model/store/persistence/PersistentStorageAgent.java
+++ b/src/main/java/codeu/model/store/persistence/PersistentStorageAgent.java
@@ -115,6 +115,11 @@ public class PersistentStorageAgent {
     persistentDataStore.writeThrough(conversation);
   }
 
+  /** Update a Conversation object's user list in the Datastore service */
+  public void updateConversation(Conversation conversation) {
+    persistentDataStore.updateConversation(conversation);
+  }
+
   /** Write a Conversation object to the Datastore service. */
   public void writeThrough(Message message) {
     persistentDataStore.writeThrough(message);

--- a/src/main/webapp/WEB-INF/view/admin.jsp
+++ b/src/main/webapp/WEB-INF/view/admin.jsp
@@ -59,9 +59,6 @@ int numConversations = ConversationStore.getInstance().getNumConversations();
   <div id="container">
     <div
       style="width:75%; margin-left:auto; margin-right:auto; margin-top: 50px;">
-      <% if (message != null) { %>
-        <p><%= message %></p>
-      <% } %>
 
       <% if (AdminHelper.isAdmin(user)) { %>
 
@@ -69,6 +66,7 @@ int numConversations = ConversationStore.getInstance().getNumConversations();
           <hr />
           <h2>Site Statistics</h2>
 
+          <p>Hello <%= user %>! Welcome to the admin page!</p>
           <p>Here are some site stats:</p>
 
           <ul>
@@ -76,12 +74,14 @@ int numConversations = ConversationStore.getInstance().getNumConversations();
             <li><b>Messages: </b><%= numMessages%></li>
             <li><b>Conversations: </b><%= numConversations%></li>
           </ul>
+          <p>
 
 		  <form method="post" action="${pageContext.request.contextPath}/admin">
 			  <input type="submit" name="deleteUsersButton" value="Delete All Users" disabled/>
 			  <input type="submit" name="deleteMessagesButton" value="Delete All Messages" disabled/>
 			  <input type="submit" name="deleteConversationsButton" value="Delete All Conversations" disabled/>
 		  </form>
+          <p>Sorry, these buttons have been disabled for the Showcase! :)</p>
 
       <% } %>
 

--- a/src/main/webapp/WEB-INF/view/admin.jsp
+++ b/src/main/webapp/WEB-INF/view/admin.jsp
@@ -77,9 +77,9 @@ int numConversations = ConversationStore.getInstance().getNumConversations();
           <p>
 
 		  <form method="post" action="${pageContext.request.contextPath}/admin">
-			  <input type="submit" name="deleteUsersButton" value="Delete All Users" disabled/>
-			  <input type="submit" name="deleteMessagesButton" value="Delete All Messages" disabled/>
-			  <input type="submit" name="deleteConversationsButton" value="Delete All Conversations" disabled/>
+			  <input type="submit" name="deleteUsersButton" value="Delete All Users" />
+			  <input type="submit" name="deleteMessagesButton" value="Delete All Messages" />
+			  <input type="submit" name="deleteConversationsButton" value="Delete All Conversations" />
 		  </form>
           <p>Sorry, these buttons have been disabled for the Showcase! :)</p>
 

--- a/src/main/webapp/WEB-INF/view/admin.jsp
+++ b/src/main/webapp/WEB-INF/view/admin.jsp
@@ -78,9 +78,9 @@ int numConversations = ConversationStore.getInstance().getNumConversations();
           </ul>
 
 		  <form method="post" action="${pageContext.request.contextPath}/admin">
-			  <input type="submit" name="deleteUsersButton" value="Delete All Users" />
-			  <input type="submit" name="deleteMessagesButton" value="Delete All Messages" />
-			  <input type="submit" name="deleteConversationsButton" value="Delete All Conversations" />
+			  <input type="submit" name="deleteUsersButton" value="Delete All Users" disabled/>
+			  <input type="submit" name="deleteMessagesButton" value="Delete All Messages" disabled/>
+			  <input type="submit" name="deleteConversationsButton" value="Delete All Conversations" disabled/>
 		  </form>
 
       <% } %>

--- a/src/main/webapp/WEB-INF/view/chat.jsp
+++ b/src/main/webapp/WEB-INF/view/chat.jsp
@@ -33,7 +33,7 @@ List<Message> messages = (List<Message>) request.getAttribute("messages");
 
   <style>
     #chat {
-      background-color: white;
+      background-color: #fcf8de;
       height: 500px;
       overflow-y: scroll
     }
@@ -103,7 +103,6 @@ List<Message> messages = (List<Message>) request.getAttribute("messages");
     <% if (user != null) { %>
     <form action="/chat/<%= conversation.getTitle() %>" method="POST">
         <input type="text" name="message">
-        <br/>
         <button type="submit" name="sendMessage">Send</button>
     </form>
 
@@ -115,7 +114,6 @@ List<Message> messages = (List<Message>) request.getAttribute("messages");
 		%>
 	    <form action="/chat/add-user/<%= conversation.getTitle() %>" method="POST">
 	        <input type="text" name="newUser">
-	        <br/>
 	        <button type="submit" name="addNewUser">Add User</button>
 	    </form>
 	  <% }

--- a/src/main/webapp/WEB-INF/view/chat.jsp
+++ b/src/main/webapp/WEB-INF/view/chat.jsp
@@ -71,7 +71,14 @@ List<Message> messages = (List<Message>) request.getAttribute("messages");
 
   <div id="container">
 
-    <h1><%= conversation.getTitle() %>
+    <%
+      String conversationTitle = conversation.getTitle();
+      if (conversation.isDirectConversation() && user != null) {
+        conversationTitle = conversation.getDirectConversationTitle(user);
+      }
+    %>
+    <h1>
+      <%= conversationTitle %>
       <a href="" style="float: right">&#8635;</a></h1>
 
     <hr/>
@@ -100,7 +107,7 @@ List<Message> messages = (List<Message>) request.getAttribute("messages");
         <button type="submit" name="sendMessage">Send</button>
     </form>
 
-      <% if (conversation.isGroupMessage()) {
+      <% if (conversation.isGroupConversation()) {
 		// check if group convo owner is current user
 	  	String name = UserStore.getInstance().getUser(conversation.getOwnerId())
 		 	.getName();

--- a/src/main/webapp/WEB-INF/view/conversations.jsp
+++ b/src/main/webapp/WEB-INF/view/conversations.jsp
@@ -19,6 +19,7 @@
 
 <%
 String user = (String) request.getSession().getAttribute("user");
+List<Conversation> conversations = (List<Conversation>) request.getAttribute("conversations");
 %>
 
 <!DOCTYPE html>
@@ -74,9 +75,7 @@ String user = (String) request.getSession().getAttribute("user");
     <h1>Conversations</h1>
 
     <%
-    List<Conversation> conversations =
-      (List<Conversation>) request.getAttribute("conversations");
-    if(conversations == null || conversations.isEmpty()){
+    if(conversations == null || conversations.isEmpty()) {
     %>
       <p>Create a conversation to get started.</p>
     <%
@@ -85,7 +84,7 @@ String user = (String) request.getSession().getAttribute("user");
     %>
       <ul class="mdl-list">
     <%
-      for(Conversation conversation : conversations){
+      for(Conversation conversation : conversations) {
     %>
       <% if (conversation.isGroupConversation()) { %>
         <li><a href="/chat/<%= conversation.getTitle() %>">
@@ -104,12 +103,12 @@ String user = (String) request.getSession().getAttribute("user");
     <hr/>
 
     <%
-    if (user != null) {
+    if (user != null && conversations != null && !conversations.isEmpty()) {
     %>
       <h1>Direct Messages</h1>
       <ul class="mdl-list">
     <%
-      for(Conversation conversation : conversations){
+      for (Conversation conversation : conversations) {
     %>
       <% if (conversation.isDirectConversation()) { %>
         <li><a href="/chat/<%= conversation.getTitle() %>">

--- a/src/main/webapp/WEB-INF/view/conversations.jsp
+++ b/src/main/webapp/WEB-INF/view/conversations.jsp
@@ -87,7 +87,10 @@ String user = (String) request.getSession().getAttribute("user");
     <%
       for(Conversation conversation : conversations){
     %>
-      <% if (conversation.isNormalConversation() || (user != null && conversation.isUserInConversation(user))) { %>
+      <% if (conversation.isGroupConversation()) { %>
+        <li><a href="/chat/<%= conversation.getTitle() %>">
+          <%= conversation.getTitle() %></a> <i>Group</i></li>
+      <% } else if (conversation.isNormalConversation()) { %>
         <li><a href="/chat/<%= conversation.getTitle() %>">
           <%= conversation.getTitle() %></a></li>
       <% } %>
@@ -99,6 +102,30 @@ String user = (String) request.getSession().getAttribute("user");
     }
     %>
     <hr/>
+
+    <%
+    if (user != null) {
+    %>
+      <h1>Direct Messages</h1>
+      <ul class="mdl-list">
+    <%
+      for(Conversation conversation : conversations){
+    %>
+      <% if (conversation.isDirectConversation()) { %>
+        <li><a href="/chat/<%= conversation.getTitle() %>">
+          <%= conversation.getDirectConversationTitle(user) %></a></li>
+      <% } %>
+    <%
+      }
+    %>
+      </ul>
+      <hr/>
+    <%
+    }
+    %>
+
+
+
   </div>
 </body>
 </html>

--- a/src/main/webapp/WEB-INF/view/profile.jsp
+++ b/src/main/webapp/WEB-INF/view/profile.jsp
@@ -14,6 +14,7 @@
   limitations under the License.
 --%>
 
+<%@ page import="codeu.helper.AdminHelper"%>
 <%@ page import="codeu.helper.ProfileHelper"%>
 <%@ page import="codeu.model.store.basic.ProfileStore"%>
 
@@ -34,12 +35,22 @@ String profileOwner = (String) request.getAttribute("profileName");
   <nav>
     <a id="navTitle" href="/">Git Rekt's Chat App</a>
     <a href="/conversations">Conversations</a>
-    <% if (user != null){ %>
+
+    <% if(user != null){ %>
       <a href="/profile/<%= user %>">Hello <%= user %>!</a>
     <% } else{ %>
       <a href="/login">Login</a>
     <% } %>
+
     <a href="/about.jsp">About</a>
+
+    <% if (AdminHelper.isAdmin(user)) { %>
+      <a href="/admin">Admin</a>
+    <% } %>
+
+    <% if (user != null) { %>
+      <a href="/logout">Logout</a>
+    <% } %>
   </nav>
 
   <div id="container">

--- a/src/main/webapp/about.jsp
+++ b/src/main/webapp/about.jsp
@@ -66,7 +66,7 @@ String user = (String) request.getSession().getAttribute("user");
             name in a Conversation! Profile pages have an "About Me" section which
             can be updated.</li>
 
-        <li><strong>HTML tags in messages:</strong> Almost all HTML tags can be
+        <li><strong>Styled Text:</strong> Almost all HTML tags can be
             used in messages, the exception being some potentially 'dangerous'
             tags like &lt;img&gt; and &lt;a&gt;!</li>
 
@@ -84,7 +84,7 @@ String user = (String) request.getSession().getAttribute("user");
             by ticking the "Group" checkbox before you create the conversation.
             The creator will be able to add other users to the group conversation
             through an "Add User" input box. Only the creator and users that are
-            added to the conversation can chat and access in it.</li>
+            added to the conversation can access it.</li>
 
       </ul>
       <h2>Developers</h2>

--- a/src/main/webapp/about.jsp
+++ b/src/main/webapp/about.jsp
@@ -89,6 +89,7 @@ String user = (String) request.getSession().getAttribute("user");
       </ul>
       <h2>Developers</h2>
       <ul>
+        <li><strong>Vasuman Ravichandran:</strong> Git Rekt's CodeU project advisor.</li>
         <li><strong>Cynthia Serrano Najera:</strong> Is a student at Wellesley
             College and studies Computer Science and Latinx Studies. She has an
             interest in photography and comic books.</li>

--- a/src/main/webapp/css/main.css
+++ b/src/main/webapp/css/main.css
@@ -20,11 +20,11 @@ body {
   font-size: 18px;
   line-height: 1.6;
   color: #444;
-  background-color: #eeeeee;
+  background-color: #fffce8;
 }
 
 nav {
-  background-color: #283593;
+  background-color: #6bc480;
 }
 
 nav a {
@@ -46,7 +46,7 @@ nav a {
 }
 
 h1 {
-  color: #757575;
+  color: #58b76e;
 }
 
 input {

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -53,7 +53,7 @@ String user = (String) request.getSession().getAttribute("user");
     <div
       style="width:75%; margin-left:auto; margin-right:auto; margin-top: 50px;">
 
-      <h1>Team 1's Chat App</h1>
+      <h1>Git Rekt's Chat App</h1>
       <h2>Welcome!</h2>
 
       <ul>

--- a/src/test/java/codeu/controller/AdminServletTest.java
+++ b/src/test/java/codeu/controller/AdminServletTest.java
@@ -85,15 +85,16 @@ public class AdminServletTest {
         Mockito.verify(mockResponse).sendRedirect("/login?error_message=notloggedin&post_login_redirect=/admin");
     }
 
-    @Test
-    public void testDoGet_UserNotAdmin() throws IOException, ServletException {
-        Mockito.when(mockSession.getAttribute("user")).thenReturn("Foobar");
-
-        adminServlet.doGet(mockRequest, mockResponse);
-
-        Mockito.verify(mockSession).setAttribute("adminMessage", "You are not an admin!");
-        Mockito.verify(mockRequestDispatcher).forward(mockRequest, mockResponse);
-    }
+    // Commented out for showcase
+//    @Test
+//    public void testDoGet_UserNotAdmin() throws IOException, ServletException {
+//        Mockito.when(mockSession.getAttribute("user")).thenReturn("Foobar");
+//
+//        adminServlet.doGet(mockRequest, mockResponse);
+//
+//        Mockito.verify(mockSession).setAttribute("adminMessage", "You are not an admin!");
+//        Mockito.verify(mockRequestDispatcher).forward(mockRequest, mockResponse);
+//    }
 
     @Test
     public void testDoGet_UserIsAdmin() throws IOException, ServletException {

--- a/src/test/java/codeu/controller/ChatAddUserServletTest.java
+++ b/src/test/java/codeu/controller/ChatAddUserServletTest.java
@@ -14,27 +14,30 @@
 
 package codeu.controller;
 
-import static codeu.model.data.Conversation.ConversationType;
-
 import codeu.model.data.Conversation;
 import codeu.model.data.User;
 import codeu.model.store.basic.ConversationStore;
-import codeu.model.store.basic.MessageStore;
 import codeu.model.store.basic.UserStore;
+import codeu.model.store.persistence.PersistentStorageAgent;
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mockito;
+
+import static codeu.model.data.Conversation.ConversationType;
 
 public class ChatAddUserServletTest {
 
@@ -42,10 +45,19 @@ public class ChatAddUserServletTest {
     private HttpServletRequest mockRequest;
     private HttpSession mockSession;
     private HttpServletResponse mockResponse;
-    private RequestDispatcher mockRequestDispatcher;
     private ConversationStore mockConversationStore;
-    private MessageStore mockMessageStore;
     private UserStore mockUserStore;
+    private final LocalServiceTestHelper helper = new LocalServiceTestHelper(new LocalDatastoreServiceTestConfig());
+
+    @Before
+    public void setUp() {
+        helper.setUp();
+    }
+
+    @After
+    public void tearDown() {
+        helper.tearDown();
+    }
 
     @Before
     public void setup() {
@@ -102,6 +114,9 @@ public class ChatAddUserServletTest {
                 .sendRedirect("/chat/" + fakeConversation.getTitle());
     }
 
+    // TODO: figure out problem of inadvertently accessing a real store in a test (addUser has to
+    // tell the Datastore service to update the list of users for the conversation)
+    // Error:
     @Test
     public void testDoPost_AddValidUserToConversation() throws IOException, ServletException {
         Mockito.when(mockRequest.getRequestURI()).thenReturn("/chat/add-user/test_conversation");

--- a/src/test/java/codeu/controller/ChatAddUserServletTest.java
+++ b/src/test/java/codeu/controller/ChatAddUserServletTest.java
@@ -19,6 +19,9 @@ import codeu.model.data.User;
 import codeu.model.store.basic.ConversationStore;
 import codeu.model.store.basic.UserStore;
 import codeu.model.store.persistence.PersistentStorageAgent;
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
 import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
 import org.junit.After;
@@ -114,9 +117,6 @@ public class ChatAddUserServletTest {
                 .sendRedirect("/chat/" + fakeConversation.getTitle());
     }
 
-    // TODO: figure out problem of inadvertently accessing a real store in a test (addUser has to
-    // tell the Datastore service to update the list of users for the conversation)
-    // Error:
     @Test
     public void testDoPost_AddValidUserToConversation() throws IOException, ServletException {
         Mockito.when(mockRequest.getRequestURI()).thenReturn("/chat/add-user/test_conversation");
@@ -138,6 +138,10 @@ public class ChatAddUserServletTest {
                         ConversationType.GROUP);
         Mockito.when(mockConversationStore.getConversationWithTitle("test_conversation"))
                 .thenReturn(fakeConversation);
+
+        // Add the conversation to the fake datastore so addUser() can update the conversation later
+        DatastoreService datastoreService = DatastoreServiceFactory.getDatastoreService();
+        datastoreService.put(new Entity("chat-conversations", fakeConversation.getId().toString()));
 
         User addedUser =
                 new User(

--- a/src/test/java/codeu/controller/ChatAddUserServletTest.java
+++ b/src/test/java/codeu/controller/ChatAddUserServletTest.java
@@ -14,6 +14,7 @@
 
 package codeu.controller;
 
+import codeu.helper.ConversationHelper;
 import codeu.model.data.Conversation;
 import codeu.model.data.User;
 import codeu.model.store.basic.ConversationStore;
@@ -96,8 +97,8 @@ public class ChatAddUserServletTest {
         users.add(fakeUser);
 
         Conversation fakeConversation =
-                new Conversation(UUID.randomUUID(), UUID.randomUUID(), "test_conversation", Instant.now(), users,
-                        ConversationType.GROUP);
+                new Conversation(UUID.randomUUID(), UUID.randomUUID(), "test_conversation", Instant.now(),
+                        ConversationHelper.getUsernamesFromUsers(users), ConversationType.GROUP);
         Mockito.when(mockConversationStore.getConversationWithTitle("test_conversation"))
                 .thenReturn(fakeConversation);
 
@@ -134,8 +135,8 @@ public class ChatAddUserServletTest {
         users.add(fakeUser);
 
         Conversation fakeConversation =
-                new Conversation(UUID.randomUUID(), UUID.randomUUID(), "test_conversation", Instant.now(), users,
-                        ConversationType.GROUP);
+                new Conversation(UUID.randomUUID(), UUID.randomUUID(), "test_conversation", Instant.now(),
+                        ConversationHelper.getUsernamesFromUsers(users), ConversationType.GROUP);
         Mockito.when(mockConversationStore.getConversationWithTitle("test_conversation"))
                 .thenReturn(fakeConversation);
 

--- a/src/test/java/codeu/controller/ChatServletTest.java
+++ b/src/test/java/codeu/controller/ChatServletTest.java
@@ -119,8 +119,12 @@ public class ChatServletTest {
     Mockito.when(mockRequest.getRequestURI()).thenReturn("/chat/private_conversation");
     Mockito.when(mockSession.getAttribute("user")).thenReturn(null);
 
+    List<String> users = new ArrayList<>();
+    users.add("UserOne");
+    users.add("UserTwo");
+
     Conversation conversation = new Conversation(UUID.randomUUID(), UUID.randomUUID(), "private_conversation",
-            Instant.now(), new ArrayList<>(), ConversationType.DIRECT);
+            Instant.now(), users, ConversationType.DIRECT);
     Mockito.when(mockConversationStore.getConversationWithTitle("private_conversation"))
             .thenReturn(conversation);
 

--- a/src/test/java/codeu/controller/ChatServletTest.java
+++ b/src/test/java/codeu/controller/ChatServletTest.java
@@ -16,6 +16,7 @@ package codeu.controller;
 
 import static codeu.model.data.Conversation.ConversationType;
 
+import codeu.helper.ConversationHelper;
 import codeu.model.data.Conversation;
 import codeu.model.data.Message;
 import codeu.model.data.User;
@@ -144,8 +145,9 @@ public class ChatServletTest {
     User user = new User(UUID.randomUUID(), "Cynthia", "testHash", Instant.now());
     ArrayList<User> users = new ArrayList<>();
     users.add(user);
+
     Conversation conversation = new Conversation(UUID.randomUUID(), UUID.randomUUID(), "private_conversation",
-            Instant.now(), users, ConversationType.GROUP);
+            Instant.now(), ConversationHelper.getUsernamesFromUsers(users), ConversationType.GROUP);
     Mockito.when(mockConversationStore.getConversationWithTitle("private_conversation"))
             .thenReturn(conversation);
 

--- a/src/test/java/codeu/controller/ConversationServletTest.java
+++ b/src/test/java/codeu/controller/ConversationServletTest.java
@@ -71,7 +71,9 @@ public class ConversationServletTest {
     List<Conversation> fakeConversationList = new ArrayList<>();
     fakeConversationList.add(
         new Conversation(UUID.randomUUID(), UUID.randomUUID(), "test_conversation", Instant.now()));
-    Mockito.when(mockConversationStore.getAllConversations()).thenReturn(fakeConversationList);
+    // Get conversations for user that is not logged in
+    Mockito.when(mockConversationStore.getConversationsForUser(null)).thenReturn(fakeConversationList);
+    Mockito.when(mockSession.getAttribute("user")).thenReturn(null);
 
     conversationServlet.doGet(mockRequest, mockResponse);
 

--- a/src/test/java/codeu/controller/ProfilePageServletTest.java
+++ b/src/test/java/codeu/controller/ProfilePageServletTest.java
@@ -14,6 +14,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
+import codeu.helper.ConversationHelper;
 import codeu.model.data.Conversation;
 import codeu.model.data.User;
 import codeu.model.store.basic.ConversationStore;
@@ -159,7 +160,7 @@ public class ProfilePageServletTest {
 		users.add(userOne);
 		users.add(userTwo);
 		Conversation conversation = new Conversation(UUID.randomUUID(), UUID.randomUUID(), "testTitle",
-				Instant.now(), users, ConversationType.DIRECT);
+				Instant.now(), ConversationHelper.getUsernamesFromUsers(users), ConversationType.DIRECT);
 
 		fakeConversationStore.addConversation(conversation);
 		Assert.assertEquals(fakeConversationStore.getNumConversations(), 1);
@@ -200,7 +201,7 @@ public class ProfilePageServletTest {
 		users.add(userOne);
 		users.add(userTwo);
 		Conversation conversation = new Conversation(UUID.randomUUID(), UUID.randomUUID(), "testTitle",
-				Instant.now(), users, ConversationType.DIRECT);
+				Instant.now(), ConversationHelper.getUsernamesFromUsers(users), ConversationType.DIRECT);
 
 		fakeConversationStore.addConversation(conversation);
 		Assert.assertEquals(fakeConversationStore.getNumConversations(), 1);

--- a/src/test/java/codeu/model/data/ConversationTest.java
+++ b/src/test/java/codeu/model/data/ConversationTest.java
@@ -31,8 +31,8 @@ public class ConversationTest {
     UUID owner = UUID.randomUUID();
     String title = "Test_Title";
     Instant creation = Instant.now();
-    List<User> users = new ArrayList<>();
-    users.add(new User(UUID.randomUUID(), "Test_Name", "Test_Hash", Instant.now()));
+    List<String> users = new ArrayList<>();
+    users.add("Test_User");
     ConversationType conversationType = ConversationType.NORMAL;
 
     Conversation conversation = new Conversation(id, owner, title, creation, users, conversationType);

--- a/src/test/java/codeu/model/data/ConversationTest.java
+++ b/src/test/java/codeu/model/data/ConversationTest.java
@@ -88,4 +88,21 @@ public class ConversationTest {
     Assert.assertEquals(conversation.isUserInConversation("Test_Name2"), false);
   }
 
+  @Test
+  public void testGetDirectConversationTitle() {
+    UUID id = UUID.randomUUID();
+    UUID owner = UUID.randomUUID();
+    String title = "Test_Title";
+    Instant creation = Instant.now();
+    List<User> users = new ArrayList<>();
+    users.add(new User(UUID.randomUUID(), "Justin", "Test_Hash", Instant.now()));
+    users.add(new User(UUID.randomUUID(), "Cynthia", "Test_Hash2", Instant.now()));
+
+    Conversation conversation = new Conversation(id, owner, title, creation, users, ConversationType.DIRECT);
+
+    // If logged in as Justin, the DM between Justin and Cynthia should have the title 'Cynthia', and vice versa
+    Assert.assertEquals("Cynthia", conversation.getDirectConversationTitle("Justin"));
+    Assert.assertEquals("Justin", conversation.getDirectConversationTitle("Cynthia"));
+  }
+
 }

--- a/src/test/java/codeu/model/data/ConversationTest.java
+++ b/src/test/java/codeu/model/data/ConversationTest.java
@@ -18,6 +18,8 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+
+import codeu.helper.ConversationHelper;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -68,7 +70,8 @@ public class ConversationTest {
     users.add(new User(UUID.randomUUID(), "Test_Name", "Test_Hash", Instant.now()));
     users.add(new User(UUID.randomUUID(), "Test_Name2", "Test_Hash2", Instant.now()));
 
-    Conversation conversation = new Conversation(id, owner, title, creation, users, ConversationType.DIRECT);
+    Conversation conversation = new Conversation(id, owner, title, creation,
+            ConversationHelper.getUsernamesFromUsers(users), ConversationType.DIRECT);
 
     Assert.assertEquals(conversation.isNormalConversation(), false);
   }
@@ -82,7 +85,8 @@ public class ConversationTest {
     List<User> users = new ArrayList<>();
     users.add(new User(UUID.randomUUID(), "Test_Name", "Test_Hash", Instant.now()));
 
-    Conversation conversation = new Conversation(id, owner, title, creation, users, ConversationType.GROUP);
+    Conversation conversation = new Conversation(id, owner, title, creation,
+            ConversationHelper.getUsernamesFromUsers(users), ConversationType.GROUP);
 
     Assert.assertEquals(conversation.isUserInConversation("Test_Name"), true);
     Assert.assertEquals(conversation.isUserInConversation("Test_Name2"), false);
@@ -98,7 +102,8 @@ public class ConversationTest {
     users.add(new User(UUID.randomUUID(), "Justin", "Test_Hash", Instant.now()));
     users.add(new User(UUID.randomUUID(), "Cynthia", "Test_Hash2", Instant.now()));
 
-    Conversation conversation = new Conversation(id, owner, title, creation, users, ConversationType.DIRECT);
+    Conversation conversation = new Conversation(id, owner, title, creation,
+            ConversationHelper.getUsernamesFromUsers(users), ConversationType.DIRECT);
 
     // If logged in as Justin, the DM between Justin and Cynthia should have the title 'Cynthia', and vice versa
     Assert.assertEquals("Cynthia", conversation.getDirectConversationTitle("Justin"));

--- a/src/test/java/codeu/model/store/basic/ConversationStoreTest.java
+++ b/src/test/java/codeu/model/store/basic/ConversationStoreTest.java
@@ -1,5 +1,6 @@
 package codeu.model.store.basic;
 
+import codeu.helper.ConversationHelper;
 import codeu.model.data.Conversation;
 import codeu.model.data.User;
 import codeu.model.store.persistence.PersistentStorageAgent;
@@ -114,11 +115,11 @@ public class ConversationStoreTest {
     users.add(userOne);
     users.add(userTwo);
     Conversation conversation = new Conversation(UUID.randomUUID(), UUID.randomUUID(), "testTitle",
-            Instant.now(), users, ConversationType.DIRECT);
+            Instant.now(), ConversationHelper.getUsernamesFromUsers(users), ConversationType.DIRECT);
 
     users.add(userThree);
     Conversation conversationTwo = new Conversation(UUID.randomUUID(), UUID.randomUUID(), "testTitle",
-            Instant.now(), users, ConversationType.DIRECT);
+            Instant.now(), ConversationHelper.getUsernamesFromUsers(users), ConversationType.DIRECT);
 
     conversationStore.addConversation(conversation);
     conversationStore.addConversation(conversationTwo);

--- a/src/test/java/codeu/model/store/basic/ConversationStoreTest.java
+++ b/src/test/java/codeu/model/store/basic/ConversationStoreTest.java
@@ -4,9 +4,8 @@ import codeu.model.data.Conversation;
 import codeu.model.data.User;
 import codeu.model.store.persistence.PersistentStorageAgent;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -126,6 +125,35 @@ public class ConversationStoreTest {
 
     Assert.assertEquals(conversationStore.getDirectMessageWithUsers("Justin", "Cynthia"), conversation);
     Assert.assertNull(conversationStore.getDirectMessageWithUsers("Cynthia", "Vasu"));
+  }
+
+  @Test
+  public void testGetConversationsForUser() {
+    List<String> usersOne = new ArrayList<>();
+    List<String> usersTwo = new ArrayList<>();
+
+    usersOne.add("Cynthia");
+    usersTwo.add("Vasu");
+
+    Conversation conversation = new Conversation(UUID.randomUUID(), UUID.randomUUID(), "testTitle",
+            Instant.now(), usersOne, ConversationType.DIRECT);
+
+    Conversation conversationTwo = new Conversation(UUID.randomUUID(), UUID.randomUUID(), "testTitle",
+            Instant.now(), usersTwo, ConversationType.DIRECT);
+
+    conversationStore.addConversation(conversation);
+    conversationStore.addConversation(conversationTwo);
+    Assert.assertEquals(3, conversationStore.getNumConversations());
+
+    Set<Conversation> expectedConversations = new HashSet<>();
+    expectedConversations.add(conversation);
+    expectedConversations.add(CONVERSATION_ONE);
+
+    Set<Conversation> actualConversations = new HashSet<>
+            ((conversationStore.getConversationsForUser("Cynthia")));
+
+    Assert.assertEquals(expectedConversations, actualConversations);
+    Assert.assertEquals(2, actualConversations.size());
   }
 
   private void assertEquals(Conversation expectedConversation, Conversation actualConversation) {

--- a/src/test/java/codeu/model/store/persistence/PersistentDataStoreTest.java
+++ b/src/test/java/codeu/model/store/persistence/PersistentDataStoreTest.java
@@ -1,13 +1,15 @@
 package codeu.model.store.persistence;
 
+import static codeu.model.data.Conversation.ConversationType;
+
 import codeu.model.data.Conversation;
 import codeu.model.data.Message;
 import codeu.model.data.User;
 import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
 import java.time.Instant;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
+
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -83,7 +85,11 @@ public class PersistentDataStoreTest {
     UUID ownerTwo = UUID.fromString("10000003-2222-3333-4444-555555555555");
     String titleTwo = "Test_Title_Two";
     Instant creationTwo = Instant.ofEpochMilli(2000);
-    Conversation inputConversationTwo = new Conversation(idTwo, ownerTwo, titleTwo, creationTwo);
+    String[] users = {"Cynthia", "Justin", "Sergio", "Vasu"};
+    List<String> usersList = Arrays.asList(users);
+
+    Conversation inputConversationTwo = new Conversation(idTwo, ownerTwo, titleTwo, creationTwo, usersList,
+            ConversationType.GROUP);
 
     // save
     persistentDataStore.writeThrough(inputConversationOne);
@@ -104,6 +110,8 @@ public class PersistentDataStoreTest {
     Assert.assertEquals(ownerTwo, resultConversationTwo.getOwnerId());
     Assert.assertEquals(titleTwo, resultConversationTwo.getTitle());
     Assert.assertEquals(creationTwo, resultConversationTwo.getCreationTime());
+    Assert.assertEquals(new HashSet<>(usersList), new HashSet<>(resultConversationTwo.getUsers()));
+    Assert.assertEquals(ConversationType.GROUP, resultConversationTwo.getConversationType());
   }
 
   @Test


### PR DESCRIPTION
**Conversation users list and type is now saved to the datastore!** This is in time to make the site work for the show case. I refactored the Conversation users list to actually store Strings (the usernames) instead of the User objects themselves to make saving and retrieving the users to the Datastore much easier, and nowhere in my code did I actually utilize the fact that I was storing the User objects over their usernames (couldn't see a real benefit to storing the User objects). Direct Messages now have their own section on the Conversations page, and the displayed title of a DM will be the user you are DMing.

**NOTE:** I've changed the Admin Page to be shown to all logged in users, and disabled the deletion buttons to get ready to upload to the Showcase
![image](https://user-images.githubusercontent.com/11599574/42976379-78d8216c-8b7e-11e8-94ed-59a057dde67d.png)
![image](https://user-images.githubusercontent.com/11599574/42976393-914cadd0-8b7e-11e8-925d-e44b29d8ed1e.png)
