### PR TITLE
Group conversation MVP and optimizations

### DIFF
--- a/src/main/java/codeu/model/data/Conversation.java
+++ b/src/main/java/codeu/model/data/Conversation.java
@@ -18,9 +18,7 @@ import codeu.model.store.basic.ConversationStore;
 
 import javax.annotation.Nullable;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 
 /**
  * Class representing a conversation, which can be thought of as a chat room. Conversations are
@@ -31,7 +29,7 @@ public class Conversation {
   public final UUID owner;
   public final Instant creation;
   public final String title;
-  public final List<String> users;
+  public final Set<String> users;
   public final ConversationType conversationType;
 
   public enum ConversationType {
@@ -51,7 +49,7 @@ public class Conversation {
     this.owner = owner;
     this.creation = creation;
     this.title = title;
-    this.users = new ArrayList<>();
+    this.users = new HashSet<>();
     this.conversationType = ConversationType.NORMAL;
   }
 
@@ -65,31 +63,13 @@ public class Conversation {
    * @param users the Users or user names that will be able to access and chat in this conversation
    * @param conversationType the type of Conversation
    */
-  public Conversation(UUID id, UUID owner, String title, Instant creation, List<?> users,
+  public Conversation(UUID id, UUID owner, String title, Instant creation, List<String> users,
                       ConversationType conversationType) {
     this.id = id;
     this.owner = owner;
     this.creation = creation;
     this.title = title;
-
-    // Check if list of Users or Strings was given
-    if (users.size() != 0) {
-      if (users.get(0) instanceof User) {
-        List<String> usernames = new ArrayList<>();
-        for (User user : (List<User>) users) {
-          usernames.add(user.getName());
-        }
-        this.users = usernames;
-      } else if (users.get(0) instanceof String) {
-        this.users = (List<String>) users;
-      } else {
-        throw new IllegalArgumentException("Users list should be of type User or String!");
-      }
-    } else {
-      this.users = new ArrayList<>();
-    }
-
-
+    this.users = new HashSet<>(users);
     this.conversationType = conversationType;
   }
 
@@ -115,7 +95,7 @@ public class Conversation {
 
   /** Returns the list of usernames that can access and chat in this Conversation */
   public List<String> getUsers() {
-    return users;
+    return new ArrayList<>(users);
   }
 
   /** Returns the number of users that can access and chat in this Conversation*/
@@ -175,7 +155,7 @@ public class Conversation {
       return false;
     }
 
-    if (users.indexOf(username) != -1) {
+    if (users.contains(username)) {
       // the user exists in the users list
       return true;
     }
@@ -195,8 +175,9 @@ public class Conversation {
       return title;
     }
 
-    String userOne = users.get(0);
-    String userTwo = users.get(1);
+    List<String> userList = new ArrayList<>(users);
+    String userOne = userList.get(0);
+    String userTwo = userList.get(1);
     if (currentUser.equals(userOne)) {
       return userTwo;
     } else if (currentUser.equals(userTwo)) {

--- a/src/main/java/codeu/model/store/basic/ConversationStore.java
+++ b/src/main/java/codeu/model/store/basic/ConversationStore.java
@@ -98,7 +98,6 @@ public class ConversationStore {
 
   /** Find and return a List of Conversations that the user is able to access and chat in */
   public List<Conversation> getConversationsForUser(String username) {
-    // TODO: decide whether or not this is needed (currently filtering conversations in conversations.jsp)
     List<Conversation> userConversations = new ArrayList<>();
 
     for (Conversation conversation : conversations) {

--- a/src/main/java/codeu/model/store/basic/UserStore.java
+++ b/src/main/java/codeu/model/store/basic/UserStore.java
@@ -89,6 +89,14 @@ public class UserStore {
   }
 
   /**
+   * Returns a List of all users in the UserStore
+   * @return List of Users
+   */
+  public List<User> getUsers() {
+    return new ArrayList<>(users.values());
+  }
+
+  /**
    * Add a new user to the current set of users known to the application. This should only be called
    * to add a new user, not to update an existing user.
    */

--- a/src/main/webapp/WEB-INF/view/admin.jsp
+++ b/src/main/webapp/WEB-INF/view/admin.jsp
@@ -81,8 +81,6 @@ int numConversations = ConversationStore.getInstance().getNumConversations();
 			  <input type="submit" name="deleteMessagesButton" value="Delete All Messages" />
 			  <input type="submit" name="deleteConversationsButton" value="Delete All Conversations" />
 		  </form>
-          <p>Sorry, these buttons have been disabled for the Showcase! :)</p>
-
       <% } %>
 
     </div>

--- a/src/main/webapp/WEB-INF/view/chat.jsp
+++ b/src/main/webapp/WEB-INF/view/chat.jsp
@@ -135,6 +135,14 @@ List<Message> messages = (List<Message>) request.getAttribute("messages");
   		} %>
       <br/>
       <hr/>
+      <% if (request.getAttribute("addNewUserMessage") != null){ %>
+          <h2><%= request.getAttribute("addNewUserMessage") %></h2>
+      <% } %>
+
+      <h4 style="display: inline">Users: </h4>
+      <% for (String username : conversation.getUsers()) { %>
+          <%= username %>
+      <% } %>
     <% } else { %>
       <p><a href="/login">Login</a> to send a message.</p>
       <hr/>
@@ -142,9 +150,11 @@ List<Message> messages = (List<Message>) request.getAttribute("messages");
 
     </div>
 
-	<% if (request.getAttribute("addNewUserMessage") != null){ %>
-        <h2><%= request.getAttribute("addNewUserMessage") %></h2>
-    <% } %>
+
+
+
+
+
 
   </div>
 

--- a/src/main/webapp/WEB-INF/view/chat.jsp
+++ b/src/main/webapp/WEB-INF/view/chat.jsp
@@ -16,6 +16,7 @@
 <%@ page import="java.util.List" %>
 <%@ page import="codeu.model.data.Conversation" %>
 <%@ page import="codeu.model.data.Message" %>
+<%@ page import="codeu.model.data.User" %>
 <%@ page import="codeu.model.store.basic.UserStore" %>
 <%@ page import="codeu.helper.AdminHelper"%>
 
@@ -101,7 +102,9 @@ List<Message> messages = (List<Message>) request.getAttribute("messages");
     <hr/>
 
     <% if (user != null) { %>
-    <form action="/chat/<%= conversation.getTitle() %>" method="POST">
+    <div>
+
+    <form action="/chat/<%= conversation.getTitle() %>" method="POST" style="float: left">
         <input type="text" name="message">
         <button type="submit" name="sendMessage">Send</button>
     </form>
@@ -112,17 +115,32 @@ List<Message> messages = (List<Message>) request.getAttribute("messages");
 		 	.getName();
 			if (user.equals(name)) {
 		%>
-	    <form action="/chat/add-user/<%= conversation.getTitle() %>" method="POST">
-	        <input type="text" name="newUser">
+
+		<% if (conversation.getNumUsers() != UserStore.getInstance().getNumUsers()) { %>
+	    <form action="/chat/add-user/<%= conversation.getTitle() %>" method="POST" style="float: right">
+	        <select name="newUser">
+	        <% List<User> users = UserStore.getInstance().getUsers();
+	           for (User currentUser : users) {
+	             String username = currentUser.getName();
+	             if (!conversation.isUserInConversation(username)) {
+	        %>
+	               <option value="<%= username %>"><%= username %></option>
+	        <%   }
+	           } %>
+	        </select>
 	        <button type="submit" name="addNewUser">Add User</button>
 	    </form>
+	    <% } %>
 	  <% }
   		} %>
+      <br/>
+      <hr/>
     <% } else { %>
       <p><a href="/login">Login</a> to send a message.</p>
+      <hr/>
     <% } %>
 
-    <hr/>
+    </div>
 
 	<% if (request.getAttribute("addNewUserMessage") != null){ %>
         <h2><%= request.getAttribute("addNewUserMessage") %></h2>

--- a/src/main/webapp/css/main.css
+++ b/src/main/webapp/css/main.css
@@ -56,3 +56,7 @@ input {
 button {
   font-size: 18px;
 }
+
+select {
+  font-size: 18px;
+}

--- a/src/test/java/codeu/model/store/basic/ConversationStoreTest.java
+++ b/src/test/java/codeu/model/store/basic/ConversationStoreTest.java
@@ -117,6 +117,7 @@ public class ConversationStoreTest {
     Conversation conversation = new Conversation(UUID.randomUUID(), UUID.randomUUID(), "testTitle",
             Instant.now(), ConversationHelper.getUsernamesFromUsers(users), ConversationType.DIRECT);
 
+    users.remove(userTwo);
     users.add(userThree);
     Conversation conversationTwo = new Conversation(UUID.randomUUID(), UUID.randomUUID(), "testTitle",
             Instant.now(), ConversationHelper.getUsernamesFromUsers(users), ConversationType.DIRECT);


### PR DESCRIPTION
I've updated the group conversations page! Instead of an input text box to add users, I've changed it to a drop down that will contain all users registered on the site excluding the users already in the conversation. Also, the bottom of the page now contains a list of the users that are a part of the conversation.
![image](https://user-images.githubusercontent.com/11599574/43360084-67cf9f7c-926c-11e8-9432-18ad600b1a72.png)

I've also added two optimizations to improve performance: 
UserStore now uses a HashMap<String, User> (Username pointing to the User object) to hold users. This one I should have had implemented waaaaaaay before!
Conversation now uses a HashSet<String> to hold users

**NOTE**: I spent quite some time trying to put the user list as a bar on the right side of the conversation, but to no avail because the alignment/margins kept going off. This is what the (so-far) failed test looked like. I still have the html/css saved in another local branch so if we had more time on this project I would make it a bigger priority since it would help the appearance side of things.
![image](https://user-images.githubusercontent.com/11599574/43360113-ec7406d2-926c-11e8-8d80-44eb9a133c9b.png)
